### PR TITLE
Add string module: ASCII

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -37,6 +38,7 @@ export const Schemable: SchemableExt2C<D.URI> = {
   Natural: Natural.Decoder,
   NegativeInt: NegativeInt.Decoder,
   PositiveInt: PositiveInt.Decoder,
+  ASCII: ASCII.Decoder,
   EmailAddress: EmailAddress.Decoder,
   ISODateString: ISODateString.Decoder,
   IntString: IntString.Decoder,

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -37,6 +38,7 @@ export const Schemable: SchemableExt1<Eq.URI> = {
   Natural: Natural.Eq,
   NegativeInt: NegativeInt.Eq,
   PositiveInt: PositiveInt.Eq,
+  ASCII: ASCII.Eq,
   EmailAddress: EmailAddress.Eq,
   ISODateString: ISODateString.Eq,
   IntString: IntString.Eq,

--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -37,6 +38,7 @@ export const Schemable: SchemableExt1<G.URI> = {
   Natural: Natural.Guard,
   NegativeInt: NegativeInt.Guard,
   PositiveInt: PositiveInt.Guard,
+  ASCII: ASCII.Guard,
   EmailAddress: EmailAddress.Guard,
   ISODateString: ISODateString.Guard,
   IntString: IntString.Guard,

--- a/src/SchemableExt.ts
+++ b/src/SchemableExt.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -36,6 +37,7 @@ export interface SchemableExt<S> extends Schemable<S> {
   readonly Natural: Natural.SchemableParams<S>
   readonly NegativeInt: NegativeInt.SchemableParams<S>
   readonly PositiveInt: PositiveInt.SchemableParams<S>
+  readonly ASCII: ASCII.SchemableParams<S>
   readonly EmailAddress: EmailAddress.SchemableParams<S>
   readonly ISODateString: ISODateString.SchemableParams<S>
   readonly IntString: IntString.SchemableParams<S>
@@ -56,6 +58,7 @@ export interface SchemableExt1<S extends URIS> extends Schemable1<S> {
   readonly Natural: Natural.SchemableParams1<S>
   readonly NegativeInt: NegativeInt.SchemableParams1<S>
   readonly PositiveInt: PositiveInt.SchemableParams1<S>
+  readonly ASCII: ASCII.SchemableParams1<S>
   readonly EmailAddress: EmailAddress.SchemableParams1<S>
   readonly ISODateString: ISODateString.SchemableParams1<S>
   readonly IntString: IntString.SchemableParams1<S>
@@ -76,6 +79,7 @@ export interface SchemableExt2C<S extends URIS2> extends Schemable2C<S, unknown>
   readonly Natural: Natural.SchemableParams2C<S>
   readonly NegativeInt: NegativeInt.SchemableParams2C<S>
   readonly PositiveInt: PositiveInt.SchemableParams2C<S>
+  readonly ASCII: ASCII.SchemableParams2C<S>
   readonly EmailAddress: EmailAddress.SchemableParams2C<S>
   readonly ISODateString: ISODateString.SchemableParams2C<S>
   readonly IntString: IntString.SchemableParams2C<S>

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -37,6 +38,7 @@ export const Schemable: SchemableExt2C<TD.URI> = {
   Natural: Natural.TaskDecoder,
   NegativeInt: NegativeInt.TaskDecoder,
   PositiveInt: PositiveInt.TaskDecoder,
+  ASCII: ASCII.TaskDecoder,
   EmailAddress: EmailAddress.TaskDecoder,
   ISODateString: ISODateString.TaskDecoder,
   IntString: IntString.TaskDecoder,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -15,6 +15,7 @@ import * as NegativeInt from './number/NegativeInt'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
+import * as ASCII from './string/ASCII'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -37,6 +38,7 @@ export const Schemable: SchemableExt1<t.URI> = {
   Natural: Natural.Type,
   NegativeInt: NegativeInt.Type,
   PositiveInt: PositiveInt.Type,
+  ASCII: ASCII.Type,
   EmailAddress: EmailAddress.Type,
   ISODateString: ISODateString.Type,
   IntString: IntString.Type,

--- a/src/string/ASCII.ts
+++ b/src/string/ASCII.ts
@@ -23,8 +23,8 @@ interface ASCIIBrand {
 /**
  * @since 0.0.1
  * @category Internal
- * @note Control Flow characters are banned by ESLint by default, however
- * these characters are valid ASCII (codes 0-30).
+ * @note Control characters are banned by ESLint by default, however
+ * these special characters are valid ASCII (codes 0-31).
  * @see https://eslint.org/docs/latest/rules/no-control-regex
  * @see https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js
  */

--- a/src/string/ASCII.ts
+++ b/src/string/ASCII.ts
@@ -1,0 +1,100 @@
+/**
+ * A string where every character is valid ASCII format.
+ *
+ * @since 0.0.1
+ */
+import { Kind, Kind2, URIS, URIS2, HKT } from 'fp-ts/HKT'
+import * as D from 'io-ts/Decoder'
+import * as Eq_ from 'fp-ts/Eq'
+import * as G from 'io-ts/Guard'
+import * as Str from 'fp-ts/string'
+import * as TD from 'io-ts/TaskDecoder'
+import * as t from 'io-ts/Type'
+import { pipe } from 'fp-ts/function'
+
+/**
+ * @since 0.0.1
+ * @category Internal
+ */
+interface ASCIIBrand {
+  readonly ASCII: unique symbol
+}
+
+/**
+ * @since 0.0.1
+ * @category Internal
+ * @see: https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js
+ * @note Control Flow characters are valid ASCII codes 0-30, thus we need to
+ * disable an otherwise useful eslint rule..
+ * https://stackoverflow.com/questions/49743842/javascript-unexpected-control-characters-in-regular-expression
+ */
+const asciiRegex = /^[\x00-\x7F]+$/ // eslint-disable-line no-control-regex
+
+/**
+ * Represents strings that contain only valid ASCII characters.
+ *
+ * @since 0.0.1
+ * @category Model
+ */
+export type ASCII = string & ASCIIBrand
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams<S> = HKT<S, ASCII>
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams1<S extends URIS> = Kind<S, ASCII>
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, ASCII>
+
+/**
+ * @since 0.0.1
+ * @category Refinements
+ */
+export const isAscii = (s: string): s is ASCII =>
+  typeof s === 'string' && asciiRegex.test(s)
+
+/**
+ * @since 0.0.1
+ * @category Instances
+ */
+export const Decoder: SchemableParams2C<D.URI> = pipe(
+  D.string,
+  D.refine(isAscii, 'ASCII')
+)
+
+/**
+ * @since 0.0.1
+ * @category Instances
+ */
+export const Eq: SchemableParams1<Eq_.URI> = Str.Eq
+
+/**
+ * @since 0.0.1
+ * @category Instances
+ */
+export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isAscii))
+
+/**
+ * @since 0.0.1
+ * @category Instances
+ */
+export const TaskDecoder: SchemableParams2C<TD.URI> = pipe(
+  TD.string,
+  TD.refine(isAscii, 'ASCII')
+)
+
+/**
+ * @since 0.0.1
+ * @category Instances
+ */
+export const Type: SchemableParams1<t.URI> = pipe(t.string, t.refine(isAscii, 'ASCII'))

--- a/src/string/ASCII.ts
+++ b/src/string/ASCII.ts
@@ -1,5 +1,5 @@
 /**
- * A string where every character is valid ASCII format.
+ * A string in which every character is valid ASCII.
  *
  * @since 0.0.1
  */
@@ -23,10 +23,10 @@ interface ASCIIBrand {
 /**
  * @since 0.0.1
  * @category Internal
- * @see: https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js
- * @note Control Flow characters are valid ASCII codes 0-30, thus we need to
- * disable an otherwise useful eslint rule..
- * https://stackoverflow.com/questions/49743842/javascript-unexpected-control-characters-in-regular-expression
+ * @note Control Flow characters are banned by ESLint by default, however
+ * these characters are valid ASCII (codes 0-30).
+ * @see https://eslint.org/docs/latest/rules/no-control-regex
+ * @see https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js
  */
 const asciiRegex = /^[\x00-\x7F]+$/ // eslint-disable-line no-control-regex
 

--- a/tests/ASCII.test.ts
+++ b/tests/ASCII.test.ts
@@ -1,0 +1,56 @@
+import { Decoder, Eq, Guard, TaskDecoder, Type } from '../src/string/ASCII'
+
+describe('ASCII', () => {
+  describe('Decoder', () => {
+    it('catches an invalid string', () => {
+      const result = Decoder.decode('ｆｏｏbar')
+      expect(result._tag).toBe('Left')
+    })
+    it('validates a valid ASCII string', () => {
+      const result = Decoder.decode('foobar123')
+      expect(result._tag).toBe('Right')
+    })
+  })
+  describe('Eq', () => {
+    it('returns true for similar strings', () => {
+      const str1 = '1234abcDEF'
+      const str2 = '1234abcDEF'
+      if (!Guard.is(str1) || !Guard.is(str2)) throw new Error('Unexpected result')
+      expect(Eq.equals(str1, str2)).toBe(true)
+    })
+    it('returns false for dissimilar dates', () => {
+      const str1 = 'abc@abc.abc'
+      const str2 = 'def@def.abc'
+      if (!Guard.is(str1) || !Guard.is(str2)) throw new Error('Unexpected result')
+      expect(Eq.equals(str1, str2)).toBe(false)
+    })
+  })
+  describe('Guard', () => {
+    it('guards against invalid ASCII characters', () => {
+      expect(Guard.is('ｆｏｏbar')).toBe(false)
+    })
+    it('permits a valid ASCII characters', () => {
+      expect(Guard.is('abc@abc.abc')).toBe(true)
+    })
+  })
+  describe('TaskDecoder', () => {
+    it('invalidates an invalid ASCII string', async () => {
+      const result = await TaskDecoder.decode('ｆｏｏbar')()
+      expect(result._tag).toBe('Left')
+    })
+    it('validates an valid ASCII string', async () => {
+      const result = await TaskDecoder.decode('abc@abc.abc')()
+      expect(result._tag).toBe('Right')
+    })
+  })
+  describe('Type', () => {
+    it('decodes an invalid ASCII string', () => {
+      const result = Type.decode('ｆｏｏbar')
+      expect(result._tag).toBe('Left')
+    })
+    it('decodes an invalid ASCII string', () => {
+      const result = Type.decode('abc@abc.abc')
+      expect(result._tag).toBe('Right')
+    })
+  })
+})

--- a/tests/EmailAddress.test.ts
+++ b/tests/EmailAddress.test.ts
@@ -12,16 +12,17 @@ describe('EmailAddress', () => {
     })
   })
   describe('Eq', () => {
-    it('returns true for similar dates', () => {
-      const email = 'abc@abc.abc'
-      if (!Guard.is(email)) throw new Error('Unexpected result')
-      expect(Eq.equals(email, email)).toBe(true)
+    it('returns true for similar email addresses', () => {
+      const email1 = 'abc@abc.abc'
+      const email2 = 'def@abc.abc'
+      if (!Guard.is(email1) || !Guard.is(email2)) throw new Error('Unexpected result')
+      expect(Eq.equals(email1, email2)).toBe(true)
     })
-    it('returns false for dissimilar dates', () => {
-      const date1 = 'abc@abc.abc'
-      const date2 = 'def@def.abc'
-      if (!Guard.is(date1) || !Guard.is(date2)) throw new Error('Unexpected result')
-      expect(Eq.equals(date1, date2)).toBe(false)
+    it('returns false for dissimilar email addresses', () => {
+      const email1 = 'abc@abc.abc'
+      const email2 = 'def@def.abc'
+      if (!Guard.is(email1) || !Guard.is(email2)) throw new Error('Unexpected result')
+      expect(Eq.equals(email1, email2)).toBe(false)
     })
   })
   describe('Guard', () => {
@@ -47,7 +48,7 @@ describe('EmailAddress', () => {
       const result = Type.decode('abc')
       expect(result._tag).toBe('Left')
     })
-    it('decodes an invalid email', () => {
+    it('decodes an valid email', () => {
       const result = Type.decode('abc@abc.abc')
       expect(result._tag).toBe('Right')
     })

--- a/tests/EmailAddress.test.ts
+++ b/tests/EmailAddress.test.ts
@@ -13,14 +13,14 @@ describe('EmailAddress', () => {
   })
   describe('Eq', () => {
     it('returns true for similar email addresses', () => {
-      const email1 = 'abc@abc.abc'
-      const email2 = 'def@abc.abc'
+      const email1 = 'abc@abc.com'
+      const email2 = 'abc@abc.com'
       if (!Guard.is(email1) || !Guard.is(email2)) throw new Error('Unexpected result')
       expect(Eq.equals(email1, email2)).toBe(true)
     })
     it('returns false for dissimilar email addresses', () => {
-      const email1 = 'abc@abc.abc'
-      const email2 = 'def@def.abc'
+      const email1 = 'abc@abc.com'
+      const email2 = 'def@def.com'
       if (!Guard.is(email1) || !Guard.is(email2)) throw new Error('Unexpected result')
       expect(Eq.equals(email1, email2)).toBe(false)
     })


### PR DESCRIPTION
closes #20

This PR does the following:
- Adds a new ASCII module. This validates that every character in a string is valid ASCII.
- Adds a test file for the ASCII module.
- Cleans up some typos in `EmailAddress.test.ts` (because that's the one I copied 🙂)


### Questions
- I wonder if we ought to try reducing some of the boilerplate in the tests? OTOH Maybe boilerplate in tests isn't such a bad thing.

### Notes
- feel free to squash+merge this PR. I got a little obsessive over one line...