### PR TITLE
Add module: Base64

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -12,16 +12,20 @@ import { SchemableExt2C } from './SchemableExt'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -37,14 +41,18 @@ export const Schemable: SchemableExt2C<D.URI> = {
   Int: Int.Decoder,
   Natural: Natural.Decoder,
   NegativeInt: NegativeInt.Decoder,
+  PositiveFloat: PositiveFloat.Decoder,
   PositiveInt: PositiveInt.Decoder,
   ASCII: ASCII.Decoder,
+  Base64: Base64.Decoder,
+  BtcAddress: BtcAddress.Decoder,
   EmailAddress: EmailAddress.Decoder,
   ISODateString: ISODateString.Decoder,
   IntString: IntString.Decoder,
   NaturalString: NaturalString.Decoder,
   NegativeIntString: NegativeIntString.Decoder,
   NonemptyString: NonemptyString.Decoder,
+  PositiveFloatString: PositiveFloatString.Decoder,
   PositiveIntString: PositiveIntString.Decoder,
   UUID: UUID.Decoder,
   SafeDate: SafeDate.Decoder,

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -45,6 +46,7 @@ export const Schemable: SchemableExt2C<D.URI> = {
   PositiveInt: PositiveInt.Decoder,
   ASCII: ASCII.Decoder,
   Base64: Base64.Decoder,
+  Base64Url: Base64Url.Decoder,
   BtcAddress: BtcAddress.Decoder,
   EmailAddress: EmailAddress.Decoder,
   ISODateString: ISODateString.Decoder,

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -12,16 +12,20 @@ import { SchemableExt1 } from './SchemableExt'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -37,14 +41,18 @@ export const Schemable: SchemableExt1<Eq.URI> = {
   Int: Int.Eq,
   Natural: Natural.Eq,
   NegativeInt: NegativeInt.Eq,
+  PositiveFloat: PositiveFloat.Eq,
   PositiveInt: PositiveInt.Eq,
   ASCII: ASCII.Eq,
+  Base64: Base64.Eq,
+  BtcAddress: BtcAddress.Eq,
   EmailAddress: EmailAddress.Eq,
   ISODateString: ISODateString.Eq,
   IntString: IntString.Eq,
   NaturalString: NaturalString.Eq,
   NegativeIntString: NegativeIntString.Eq,
   NonemptyString: NonemptyString.Eq,
+  PositiveFloatString: PositiveFloatString.Eq,
   PositiveIntString: PositiveIntString.Eq,
   UUID: UUID.Eq,
   SafeDate: SafeDate.Eq,

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -45,6 +46,7 @@ export const Schemable: SchemableExt1<Eq.URI> = {
   PositiveInt: PositiveInt.Eq,
   ASCII: ASCII.Eq,
   Base64: Base64.Eq,
+  Base64Url: Base64Url.Eq,
   BtcAddress: BtcAddress.Eq,
   EmailAddress: EmailAddress.Eq,
   ISODateString: ISODateString.Eq,

--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -45,6 +46,7 @@ export const Schemable: SchemableExt1<G.URI> = {
   PositiveInt: PositiveInt.Guard,
   ASCII: ASCII.Guard,
   Base64: Base64.Guard,
+  Base64Url: Base64Url.Guard,
   BtcAddress: BtcAddress.Guard,
   EmailAddress: EmailAddress.Guard,
   ISODateString: ISODateString.Guard,

--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -12,16 +12,20 @@ import { SchemableExt1 } from './SchemableExt'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -37,14 +41,18 @@ export const Schemable: SchemableExt1<G.URI> = {
   Int: Int.Guard,
   Natural: Natural.Guard,
   NegativeInt: NegativeInt.Guard,
+  PositiveFloat: PositiveFloat.Guard,
   PositiveInt: PositiveInt.Guard,
   ASCII: ASCII.Guard,
+  Base64: Base64.Guard,
+  BtcAddress: BtcAddress.Guard,
   EmailAddress: EmailAddress.Guard,
   ISODateString: ISODateString.Guard,
   IntString: IntString.Guard,
   NaturalString: NaturalString.Guard,
   NegativeIntString: NegativeIntString.Guard,
   NonemptyString: NonemptyString.Guard,
+  PositiveFloatString: PositiveFloatString.Guard,
   PositiveIntString: PositiveIntString.Guard,
   UUID: UUID.Guard,
   SafeDate: SafeDate.Guard,

--- a/src/SchemableExt.ts
+++ b/src/SchemableExt.ts
@@ -12,16 +12,20 @@ import { Schemable, Schemable1, Schemable2C } from 'io-ts/Schemable'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -36,14 +40,18 @@ export interface SchemableExt<S> extends Schemable<S> {
   readonly Int: Int.SchemableParams<S>
   readonly Natural: Natural.SchemableParams<S>
   readonly NegativeInt: NegativeInt.SchemableParams<S>
+  readonly PositiveFloat: PositiveFloat.SchemableParams<S>
   readonly PositiveInt: PositiveInt.SchemableParams<S>
   readonly ASCII: ASCII.SchemableParams<S>
+  readonly Base64: Base64.SchemableParams<S>
+  readonly BtcAddress: BtcAddress.SchemableParams<S>
   readonly EmailAddress: EmailAddress.SchemableParams<S>
   readonly ISODateString: ISODateString.SchemableParams<S>
   readonly IntString: IntString.SchemableParams<S>
   readonly NaturalString: NaturalString.SchemableParams<S>
   readonly NegativeIntString: NegativeIntString.SchemableParams<S>
   readonly NonemptyString: NonemptyString.SchemableParams<S>
+  readonly PositiveFloatString: PositiveFloatString.SchemableParams<S>
   readonly PositiveIntString: PositiveIntString.SchemableParams<S>
   readonly UUID: UUID.SchemableParams<S>
   readonly SafeDate: SafeDate.SchemableParams<S>
@@ -57,14 +65,18 @@ export interface SchemableExt1<S extends URIS> extends Schemable1<S> {
   readonly Int: Int.SchemableParams1<S>
   readonly Natural: Natural.SchemableParams1<S>
   readonly NegativeInt: NegativeInt.SchemableParams1<S>
+  readonly PositiveFloat: PositiveFloat.SchemableParams1<S>
   readonly PositiveInt: PositiveInt.SchemableParams1<S>
   readonly ASCII: ASCII.SchemableParams1<S>
+  readonly Base64: Base64.SchemableParams1<S>
+  readonly BtcAddress: BtcAddress.SchemableParams1<S>
   readonly EmailAddress: EmailAddress.SchemableParams1<S>
   readonly ISODateString: ISODateString.SchemableParams1<S>
   readonly IntString: IntString.SchemableParams1<S>
   readonly NaturalString: NaturalString.SchemableParams1<S>
   readonly NegativeIntString: NegativeIntString.SchemableParams1<S>
   readonly NonemptyString: NonemptyString.SchemableParams1<S>
+  readonly PositiveFloatString: PositiveFloatString.SchemableParams1<S>
   readonly PositiveIntString: PositiveIntString.SchemableParams1<S>
   readonly UUID: UUID.SchemableParams1<S>
   readonly SafeDate: SafeDate.SchemableParams1<S>
@@ -78,14 +90,18 @@ export interface SchemableExt2C<S extends URIS2> extends Schemable2C<S, unknown>
   readonly Int: Int.SchemableParams2C<S>
   readonly Natural: Natural.SchemableParams2C<S>
   readonly NegativeInt: NegativeInt.SchemableParams2C<S>
+  readonly PositiveFloat: PositiveFloat.SchemableParams2C<S>
   readonly PositiveInt: PositiveInt.SchemableParams2C<S>
   readonly ASCII: ASCII.SchemableParams2C<S>
+  readonly Base64: Base64.SchemableParams2C<S>
+  readonly BtcAddress: BtcAddress.SchemableParams2C<S>
   readonly EmailAddress: EmailAddress.SchemableParams2C<S>
   readonly ISODateString: ISODateString.SchemableParams2C<S>
   readonly IntString: IntString.SchemableParams2C<S>
   readonly NaturalString: NaturalString.SchemableParams2C<S>
   readonly NegativeIntString: NegativeIntString.SchemableParams2C<S>
   readonly NonemptyString: NonemptyString.SchemableParams2C<S>
+  readonly PositiveFloatString: PositiveFloatString.SchemableParams2C<S>
   readonly PositiveIntString: PositiveIntString.SchemableParams2C<S>
   readonly UUID: UUID.SchemableParams2C<S>
   readonly SafeDate: SafeDate.SchemableParams2C<S>

--- a/src/SchemableExt.ts
+++ b/src/SchemableExt.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -44,6 +45,7 @@ export interface SchemableExt<S> extends Schemable<S> {
   readonly PositiveInt: PositiveInt.SchemableParams<S>
   readonly ASCII: ASCII.SchemableParams<S>
   readonly Base64: Base64.SchemableParams<S>
+  readonly Base64Url: Base64Url.SchemableParams<S>
   readonly BtcAddress: BtcAddress.SchemableParams<S>
   readonly EmailAddress: EmailAddress.SchemableParams<S>
   readonly ISODateString: ISODateString.SchemableParams<S>
@@ -69,6 +71,7 @@ export interface SchemableExt1<S extends URIS> extends Schemable1<S> {
   readonly PositiveInt: PositiveInt.SchemableParams1<S>
   readonly ASCII: ASCII.SchemableParams1<S>
   readonly Base64: Base64.SchemableParams1<S>
+  readonly Base64Url: Base64Url.SchemableParams1<S>
   readonly BtcAddress: BtcAddress.SchemableParams1<S>
   readonly EmailAddress: EmailAddress.SchemableParams1<S>
   readonly ISODateString: ISODateString.SchemableParams1<S>
@@ -94,6 +97,7 @@ export interface SchemableExt2C<S extends URIS2> extends Schemable2C<S, unknown>
   readonly PositiveInt: PositiveInt.SchemableParams2C<S>
   readonly ASCII: ASCII.SchemableParams2C<S>
   readonly Base64: Base64.SchemableParams2C<S>
+  readonly Base64Url: Base64Url.SchemableParams2C<S>
   readonly BtcAddress: BtcAddress.SchemableParams2C<S>
   readonly EmailAddress: EmailAddress.SchemableParams2C<S>
   readonly ISODateString: ISODateString.SchemableParams2C<S>

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -45,6 +46,7 @@ export const Schemable: SchemableExt2C<TD.URI> = {
   PositiveInt: PositiveInt.TaskDecoder,
   ASCII: ASCII.TaskDecoder,
   Base64: Base64.TaskDecoder,
+  Base64Url: Base64Url.TaskDecoder,
   BtcAddress: BtcAddress.TaskDecoder,
   EmailAddress: EmailAddress.TaskDecoder,
   ISODateString: ISODateString.TaskDecoder,

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -12,16 +12,20 @@ import { SchemableExt2C } from './SchemableExt'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -37,14 +41,18 @@ export const Schemable: SchemableExt2C<TD.URI> = {
   Int: Int.TaskDecoder,
   Natural: Natural.TaskDecoder,
   NegativeInt: NegativeInt.TaskDecoder,
+  PositiveFloat: PositiveFloat.TaskDecoder,
   PositiveInt: PositiveInt.TaskDecoder,
   ASCII: ASCII.TaskDecoder,
+  Base64: Base64.TaskDecoder,
+  BtcAddress: BtcAddress.TaskDecoder,
   EmailAddress: EmailAddress.TaskDecoder,
   ISODateString: ISODateString.TaskDecoder,
   IntString: IntString.TaskDecoder,
   NaturalString: NaturalString.TaskDecoder,
   NegativeIntString: NegativeIntString.TaskDecoder,
   NonemptyString: NonemptyString.TaskDecoder,
+  PositiveFloatString: PositiveFloatString.TaskDecoder,
   PositiveIntString: PositiveIntString.TaskDecoder,
   UUID: UUID.TaskDecoder,
   SafeDate: SafeDate.TaskDecoder,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -18,6 +18,7 @@ import * as PositiveInt from './number/PositiveInt'
 /** String */
 import * as ASCII from './string/ASCII'
 import * as Base64 from './string/Base64'
+import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
@@ -45,6 +46,7 @@ export const Schemable: SchemableExt1<t.URI> = {
   PositiveInt: PositiveInt.Type,
   ASCII: ASCII.Type,
   Base64: Base64.Type,
+  Base64Url: Base64Url.Type,
   BtcAddress: BtcAddress.Type,
   EmailAddress: EmailAddress.Type,
   ISODateString: ISODateString.Type,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -12,16 +12,20 @@ import { SchemableExt1 } from './SchemableExt'
 import * as Int from './number/Int'
 import * as Natural from './number/Natural'
 import * as NegativeInt from './number/NegativeInt'
+import * as PositiveFloat from './number/PositiveFloat'
 import * as PositiveInt from './number/PositiveInt'
 
 /** String */
 import * as ASCII from './string/ASCII'
+import * as Base64 from './string/Base64'
+import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as NaturalString from './string/NaturalString'
 import * as NegativeIntString from './string/NegativeIntString'
 import * as NonemptyString from './string/NonemptyString'
+import * as PositiveFloatString from './string/PositiveFloatString'
 import * as PositiveIntString from './string/PositiveIntString'
 import * as UUID from './string/UUID'
 
@@ -37,14 +41,18 @@ export const Schemable: SchemableExt1<t.URI> = {
   Int: Int.Type,
   Natural: Natural.Type,
   NegativeInt: NegativeInt.Type,
+  PositiveFloat: PositiveFloat.Type,
   PositiveInt: PositiveInt.Type,
   ASCII: ASCII.Type,
+  Base64: Base64.Type,
+  BtcAddress: BtcAddress.Type,
   EmailAddress: EmailAddress.Type,
   ISODateString: ISODateString.Type,
   IntString: IntString.Type,
   NaturalString: NaturalString.Type,
   NegativeIntString: NegativeIntString.Type,
   NonemptyString: NonemptyString.Type,
+  PositiveFloatString: PositiveFloatString.Type,
   PositiveIntString: PositiveIntString.Type,
   UUID: UUID.Type,
   SafeDate: SafeDate.Type,

--- a/src/string/ASCII.ts
+++ b/src/string/ASCII.ts
@@ -1,8 +1,8 @@
 /**
  * A string in which every character is valid ASCII.
  *
- * - This is heavily inspired by the `validator.js` module
- *   [`isAscii`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js).
+ * This is heavily inspired by the `validator.js` module
+ * [`isAscii`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isAscii.js).
  *
  * @since 0.0.1
  */

--- a/src/string/Base64.ts
+++ b/src/string/Base64.ts
@@ -1,0 +1,136 @@
+/**
+ * Representing a Base64 encoded string. Strings are URL-safe by default, but can be made
+ * non-safe by providing an option to the constructor, e.g...
+ *
+ * ```ts
+ * const decoder = Base64.Decoder({ urlSafe: false })
+ * ```
+ *
+ * This module is heavily inspired by the `validator.js` module
+ * [`isBase64`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isBase64.js).
+ *
+ * @since 0.0.2
+ */
+import { Kind, Kind2, URIS, URIS2, HKT } from 'fp-ts/HKT'
+import * as D from 'io-ts/Decoder'
+import * as Eq_ from 'fp-ts/Eq'
+import * as G from 'io-ts/Guard'
+import * as Str from 'fp-ts/string'
+import * as TD from 'io-ts/TaskDecoder'
+import * as t from 'io-ts/Type'
+import { pipe } from 'fp-ts/function'
+
+/**
+ * @since 0.0.2
+ * @category Internal
+ */
+interface Base64Brand {
+  readonly Base64: unique symbol
+}
+
+/**
+ * Representing a Base64 encoded string.
+ *
+ * Heavily inspired by the `validator.js` module
+ * [`isBase64`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isBase64.js).
+ *
+ * @since 0.0.2
+ * @category Model
+ */
+export type Base64 = string & Base64Brand
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type Base64SchemableOptions = {
+  urlSafe: boolean
+}
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams<S> = (options?: Base64SchemableOptions) => HKT<S, Base64>
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams1<S extends URIS> = (
+  options?: Base64SchemableOptions
+) => Kind<S, Base64>
+
+/**
+ * @since 0.0.1
+ * @category Model
+ */
+export type SchemableParams2C<S extends URIS2> = (
+  options?: Base64SchemableOptions
+) => Kind2<S, unknown, Base64>
+
+const notBase64 = /[^A-Z0-9+/=]/i
+const urlSafeBase64 = /^[A-Z0-9_-]*$/i
+
+const defaultBase64Options: Base64SchemableOptions = {
+  urlSafe: true,
+}
+
+/**
+ * @since 0.0.2
+ * @category Refinements
+ */
+export const isBase64 =
+  (options = defaultBase64Options) =>
+  (s: string): s is Base64 => {
+    const len = s.length
+
+    if (options.urlSafe) {
+      return urlSafeBase64.test(s)
+    }
+
+    if (len % 4 !== 0 || notBase64.test(s)) {
+      return false
+    }
+
+    const firstPaddingChar = s.indexOf('=')
+    return (
+      firstPaddingChar === -1 ||
+      firstPaddingChar === len - 1 ||
+      (firstPaddingChar === len - 2 && s[len - 1] === '=')
+    )
+  }
+
+/**
+ * @since 0.0.2
+ * @category Instances
+ */
+export const Decoder: SchemableParams2C<D.URI> = options =>
+  pipe(D.string, D.refine(isBase64(options), 'Base64'))
+
+/**
+ * @since 0.0.2
+ * @category Instances
+ */
+export const Eq: SchemableParams1<Eq_.URI> = () => Str.Eq
+
+/**
+ * @since 0.0.2
+ * @category Instances
+ */
+export const Guard: SchemableParams1<G.URI> = options =>
+  pipe(G.string, G.refine(isBase64(options)))
+
+/**
+ * @since 0.0.2
+ * @category Instances
+ */
+export const TaskDecoder: SchemableParams2C<TD.URI> = options =>
+  pipe(TD.string, TD.refine(isBase64(options), 'Base64'))
+
+/**
+ * @since 0.0.2
+ * @category Instances
+ */
+export const Type: SchemableParams1<t.URI> = options =>
+  pipe(t.string, t.refine(isBase64(options), 'Base64'))

--- a/src/string/Base64Url.ts
+++ b/src/string/Base64Url.ts
@@ -1,7 +1,7 @@
 /**
- * Representing a Base64-encoded string.
+ * Representing a URL-safe, Base64 encoded string.
  *
- * For a URL-safe version, @see Base64UrlSafe module
+ * For a non-URL-safe alternative, @see Base64
  *
  * This module is heavily inspired by the `validator.js` module
  * [`isBase64`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isBase64.js).
@@ -21,14 +21,14 @@ import { pipe } from 'fp-ts/function'
  * @since 0.0.2
  * @category Internal
  */
-interface Base64Brand {
-  readonly Base64: unique symbol
+interface Base64UrlBrand {
+  readonly Base64Url: unique symbol
 }
 
 /**
- * Representing a Base64-encoded string.
+ * Representing a URL-safe, Base64 encoded string.
  *
- * For a URL-safe version, @see Base64Url module.
+ * For a non-URL-safe alternative, @see Base64
  *
  * Heavily inspired by the `validator.js` module
  * [`isBase64`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isBase64.js).
@@ -36,51 +36,37 @@ interface Base64Brand {
  * @since 0.0.2
  * @category Model
  */
-export type Base64 = string & Base64Brand
+export type Base64Url = string & Base64UrlBrand
 
 /**
  * @since 0.0.2
  * @category Model
  */
-export type SchemableParams<S> = HKT<S, Base64>
+export type SchemableParams<S> = HKT<S, Base64Url>
 
 /**
  * @since 0.0.2
  * @category Model
  */
-export type SchemableParams1<S extends URIS> = Kind<S, Base64>
+export type SchemableParams1<S extends URIS> = Kind<S, Base64Url>
 
 /**
  * @since 0.0.2
  * @category Model
  */
-export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, Base64>
+export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, Base64Url>
 
 /**
  * @since 0.0.2
  * @category Internal
  */
-const notBase64 = /[^A-Z0-9+/=]/i
+const urlSafeBase64 = /^[A-Z0-9_-]*$/i
 
 /**
  * @since 0.0.2
  * @category Refinements
  */
-export const isBase64 = (s: string): s is Base64 => {
-  const len = s.length
-
-  if (len % 4 !== 0 || notBase64.test(s)) {
-    return false
-  }
-
-  const firstPaddingChar = s.indexOf('=')
-
-  return (
-    firstPaddingChar === -1 ||
-    firstPaddingChar === len - 1 ||
-    (firstPaddingChar === len - 2 && s[len - 1] === '=')
-  )
-}
+export const isBase64Url = (s: string): s is Base64Url => urlSafeBase64.test(s)
 
 /**
  * @since 0.0.2
@@ -88,7 +74,7 @@ export const isBase64 = (s: string): s is Base64 => {
  */
 export const Decoder: SchemableParams2C<D.URI> = pipe(
   D.string,
-  D.refine(isBase64, 'Base64')
+  D.refine(isBase64Url, 'Base64Url')
 )
 
 /**
@@ -101,7 +87,7 @@ export const Eq: SchemableParams1<Eq_.URI> = Str.Eq
  * @since 0.0.2
  * @category Instances
  */
-export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isBase64))
+export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isBase64Url))
 
 /**
  * @since 0.0.2
@@ -109,11 +95,14 @@ export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isBase64))
  */
 export const TaskDecoder: SchemableParams2C<TD.URI> = pipe(
   TD.string,
-  TD.refine(isBase64, 'Base64')
+  TD.refine(isBase64Url, 'Base64Url')
 )
 
 /**
  * @since 0.0.2
  * @category Instances
  */
-export const Type: SchemableParams1<t.URI> = pipe(t.string, t.refine(isBase64, 'Base64'))
+export const Type: SchemableParams1<t.URI> = pipe(
+  t.string,
+  t.refine(isBase64Url, 'Base64Url')
+)

--- a/tests/Base64.test.ts
+++ b/tests/Base64.test.ts
@@ -8,20 +8,32 @@ import { cat, combineExpected } from '../test-utils'
 
 const validStrings = [
   '',
-  'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ',
-  '1234',
-  'bXVtLW5ldmVyLXByb3Vk',
-  'PDw_Pz8-Pg',
-  'VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw',
+  'Zg==',
+  'Zm8=',
+  'Zm9v',
+  'Zm9vYg==',
+  'Zm9vYmE=',
+  'Zm9vYmFy',
+  'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4=',
+  'Vml2YW11cyBmZXJtZW50dW0gc2VtcGVyIHBvcnRhLg==',
+  'U3VzcGVuZGlzc2UgbGVjdHVzIGxlbw==',
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMPNS1Ufof9EW/M98FNw' +
+    'UAKrwflsqVxaxQjBQnHQmiI7Vac40t8x7pIb8gLGV6wL7sBTJiPovJ0V7y7oc0Ye' +
+    'rhKh0Rm4skP2z/jHwwZICgGzBvA0rH8xlhUiTvcwDCJ0kc+fh35hNt8srZQM4619' +
+    'FTgB66Xmp4EtVyhpQV+t02g6NzK72oZI0vnAvqhpkxLeLiMCyrI416wHm5Tkukhx' +
+    'QmcL2a6hNOyu0ixX/x2kSFXApEnVrJ+/IxGyfyw8kf4N2IZpW5nEP847lpfj0SZZ' +
+    'Fwrd1mnfnDbYohX2zRptLy2ZUn06Qo9pkG5ntvFEPo9bfZeULtjYzIl6K8gJ2uGZ' +
+    'HQIDAQAB',
 ]
 
 const invalidStrings = [
-  ' AA',
-  '\tAA',
-  '\rAA',
-  '\nAA',
-  'This+isa/bad+base64Url==',
-  '0K3RgtC+INC30LDQutC+0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw',
+  '12345',
+  'Vml2YW11cyBmZXJtZtesting123',
+  'Zg=',
+  'Z===',
+  'Zm=8',
+  '=m9vYg==',
+  'Zm9vYmFy====',
 ]
 
 describe('Base64', () => {
@@ -29,7 +41,7 @@ describe('Base64', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
     )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Decoder().decode(num)
+      const result = Decoder.decode(num)
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -40,8 +52,8 @@ describe('Base64', () => {
       'determines two strings are equal',
 
       (num1, num2) => {
-        const guard = Guard({ urlSafe: true }).is
-        const eq = Eq().equals
+        const guard = Guard.is
+        const eq = Eq.equals
 
         if (!guard(num1) || !guard(num2)) {
           throw new Error('Unexpected result')
@@ -56,7 +68,7 @@ describe('Base64', () => {
     test.each(
       cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
     )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Guard({ urlSafe: true }).is(num)
+      const result = Guard.is(num)
 
       expect(result).toBe(expectedTag)
     })
@@ -66,7 +78,7 @@ describe('Base64', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
     )('validates valid strings, and catches bad strings', async (num, expectedTag) => {
-      const result = await TaskDecoder({ urlSafe: true }).decode(num)()
+      const result = await TaskDecoder.decode(num)()
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -76,7 +88,7 @@ describe('Base64', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
     )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Type({ urlSafe: true }).decode(num)
+      const result = Type.decode(num)
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -87,10 +99,24 @@ describe('Base64', () => {
       str += String.fromCharCode((Math.random() * 26) | 97)
       encoded = Buffer.from(str).toString('base64')
 
-      if (!isBase64({ urlSafe: false })(encoded)) {
+      if (!isBase64(encoded)) {
         const msg = `validator.isBase64() failed with "${encoded}"`
         throw new Error(msg)
       }
     }
+  })
+
+  describe('isBase64', () => {
+    const str = `hQGkA8uYb/u24XuEAQzAh5dH2QUPv5rQ+uHwVQQShCgmgJzlOAq+L6Ld4l4P0MOeUYK7Zvt7HiYM
+MzH5Pdi+VfiW0JWDqTdvQZS6o0SfBzoZqwqplAofLH+7hlu8qS0n6FFxXk2b4N5InMf/zWlqpDb6
+oeGZQBbLJy69drKzpJYvqMM+OuzLUA4Wwv/WfwGtHo/fQ3H2JSFwPJz3QHuqvTrnIhO23fZa8Qpd
+M36LBbX3yqrmrJo63NHy9QL9eF6+/WU7qsKOxGSm2QlDaREKx6ZlXgZ+FY7SEt1C6PHPXhggf4Ts
+EF5rb+0goEniDbgiofYpUt0+aLkwsNnMYHx0+yAelPP45ZbCKxQe1Tk3gq5oAspWvUAvt6SqmNW5
+CrakBXYSIpNqHWdjdW75yeUYPKIi1X1SZi1mVGy0ayrOGoPbOY6C77JwGMxqEOZtDLBiy/u9g1II
+Zy1dm3UxhX/Tir2Cg+5kTAVQ6qqliklhGSCcYw0rNMfl+q151zKu4/j9id5pHnrkjnjrV1odz3u/
+aBKxLpzf8cf2BlYdRooqvFIbdJULftmn0lABukKc0eaPclSdz//DzTU318fpHnFbzlUpi82UVNL4
+IUqUviQNw7SX41v90N39iNP3JmczkN8J70+o7NLYlcvp4xXIFOcRaDrinbCcXT1WfQ==`
+
+    expect(isBase64(str)).toBeTruthy
   })
 })

--- a/tests/Base64.test.ts
+++ b/tests/Base64.test.ts
@@ -1,0 +1,96 @@
+import * as RA from 'fp-ts/ReadonlyArray'
+
+import { tuple } from 'fp-ts/function'
+
+import { Decoder, Eq, Guard, isBase64, TaskDecoder, Type } from '../src/string/Base64'
+
+import { cat, combineExpected } from '../test-utils'
+
+const validStrings = [
+  '',
+  'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ',
+  '1234',
+  'bXVtLW5ldmVyLXByb3Vk',
+  'PDw_Pz8-Pg',
+  'VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw',
+]
+
+const invalidStrings = [
+  ' AA',
+  '\tAA',
+  '\rAA',
+  '\nAA',
+  'This+isa/bad+base64Url==',
+  '0K3RgtC+INC30LDQutC+0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw',
+]
+
+describe('Base64', () => {
+  describe('Decoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Decoder().decode(num)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Eq', () => {
+    test.each(RA.zipWith(validStrings, validStrings, tuple))(
+      'determines two strings are equal',
+
+      (num1, num2) => {
+        const guard = Guard({ urlSafe: true }).is
+        const eq = Eq().equals
+
+        if (!guard(num1) || !guard(num2)) {
+          throw new Error('Unexpected result')
+        }
+
+        expect(eq(num1, num2)).toBe(true)
+      }
+    )
+  })
+
+  describe('Guard', () => {
+    test.each(
+      cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Guard({ urlSafe: true }).is(num)
+
+      expect(result).toBe(expectedTag)
+    })
+  })
+
+  describe('TaskDecoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', async (num, expectedTag) => {
+      const result = await TaskDecoder({ urlSafe: true }).decode(num)()
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Type', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Type({ urlSafe: true }).decode(num)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Very long, non-url safe string', () => {
+    for (let i = 0, str = '', encoded; i < 1000; i++) {
+      str += String.fromCharCode((Math.random() * 26) | 97)
+      encoded = Buffer.from(str).toString('base64')
+
+      if (!isBase64({ urlSafe: false })(encoded)) {
+        const msg = `validator.isBase64() failed with "${encoded}"`
+        throw new Error(msg)
+      }
+    }
+  })
+})

--- a/tests/Base64Url.test.ts
+++ b/tests/Base64Url.test.ts
@@ -1,0 +1,84 @@
+import * as RA from 'fp-ts/ReadonlyArray'
+
+import { tuple } from 'fp-ts/function'
+
+import { Decoder, Eq, Guard, TaskDecoder, Type } from '../src/string/Base64Url'
+
+import { cat, combineExpected } from '../test-utils'
+
+const validStrings = [
+  '',
+  'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ',
+  '1234',
+  'bXVtLW5ldmVyLXByb3Vk',
+  'PDw_Pz8-Pg',
+  'VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw',
+]
+
+const invalidStrings = [
+  ' AA',
+  '\tAA',
+  '\rAA',
+  '\nAA',
+  'This+isa/bad+base64Url==',
+  '0K3RgtC+INC30LDQutC+0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw',
+]
+
+describe('Base64Url', () => {
+  describe('Decoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Decoder.decode(num)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Eq', () => {
+    test.each(RA.zipWith(validStrings, validStrings, tuple))(
+      'determines two strings are equal',
+
+      (num1, num2) => {
+        const guard = Guard.is
+        const eq = Eq.equals
+
+        if (!guard(num1) || !guard(num2)) {
+          throw new Error('Unexpected result')
+        }
+
+        expect(eq(num1, num2)).toBe(true)
+      }
+    )
+  })
+
+  describe('Guard', () => {
+    test.each(
+      cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Guard.is(num)
+
+      expect(result).toBe(expectedTag)
+    })
+  })
+
+  describe('TaskDecoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', async (num, expectedTag) => {
+      const result = await TaskDecoder.decode(num)()
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Type', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
+      const result = Type.decode(num)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+})


### PR DESCRIPTION
closes #23
closes #44 

Note:
- ~I diverted slightly from the `validator.js` module by making these url-safe by default. I don't have a great rationale for doing this, aside from it felt like the more correct general use-case.~ (Ended up adding a new module, `Base64Url`.
- This also contains some additional generated code that resulted from running `yarn generate:schemables`

### Follow-up [edited]
- I learned quite a bit about Base64 encoding (and specifically [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648)), I think I'd like to follow up on this and potentially provide different modules that check that we're fully adhering to the spec.. but for now at least, this just follows the same checks provided by `validator.js`.