### PR TITLE
[#61][#18] Add `Hexadecimal` and `HexColor` modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         node-version:
           - 14.x
           - 16.x
+          - 18.x
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemable-ts-types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "This package exposes io-ts-types built for use with Schema and Schemable in io-ts.",
   "homepage": "https://jacob-alford.github.io/schemable-ts-types/",
   "repository": "https://github.com/jacob-alford/schemable-ts-types",

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt2C<D.URI> = {
   Base64Url: Base64Url.Decoder,
   BtcAddress: BtcAddress.Decoder,
   EmailAddress: EmailAddress.Decoder,
+  HexColor: HexColor.Decoder,
   Hexadecimal: Hexadecimal.Decoder,
   ISODateString: ISODateString.Decoder,
   IntString: IntString.Decoder,

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt2C<D.URI> = {
   Base64Url: Base64Url.Decoder,
   BtcAddress: BtcAddress.Decoder,
   EmailAddress: EmailAddress.Decoder,
+  Hexadecimal: Hexadecimal.Decoder,
   ISODateString: ISODateString.Decoder,
   IntString: IntString.Decoder,
   JWT: JWT.Decoder,

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt2<Enc.URI> = {
   Base64Url: Base64Url.Encoder,
   BtcAddress: BtcAddress.Encoder,
   EmailAddress: EmailAddress.Encoder,
+  HexColor: HexColor.Encoder,
   Hexadecimal: Hexadecimal.Encoder,
   ISODateString: ISODateString.Encoder,
   IntString: IntString.Encoder,

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt2<Enc.URI> = {
   Base64Url: Base64Url.Encoder,
   BtcAddress: BtcAddress.Encoder,
   EmailAddress: EmailAddress.Encoder,
+  Hexadecimal: Hexadecimal.Encoder,
   ISODateString: ISODateString.Encoder,
   IntString: IntString.Encoder,
   JWT: JWT.Encoder,

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt1<Eq.URI> = {
   Base64Url: Base64Url.Eq,
   BtcAddress: BtcAddress.Eq,
   EmailAddress: EmailAddress.Eq,
+  HexColor: HexColor.Eq,
   Hexadecimal: Hexadecimal.Eq,
   ISODateString: ISODateString.Eq,
   IntString: IntString.Eq,

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt1<Eq.URI> = {
   Base64Url: Base64Url.Eq,
   BtcAddress: BtcAddress.Eq,
   EmailAddress: EmailAddress.Eq,
+  Hexadecimal: Hexadecimal.Eq,
   ISODateString: ISODateString.Eq,
   IntString: IntString.Eq,
   JWT: JWT.Eq,

--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt1<G.URI> = {
   Base64Url: Base64Url.Guard,
   BtcAddress: BtcAddress.Guard,
   EmailAddress: EmailAddress.Guard,
+  Hexadecimal: Hexadecimal.Guard,
   ISODateString: ISODateString.Guard,
   IntString: IntString.Guard,
   JWT: JWT.Guard,

--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt1<G.URI> = {
   Base64Url: Base64Url.Guard,
   BtcAddress: BtcAddress.Guard,
   EmailAddress: EmailAddress.Guard,
+  HexColor: HexColor.Guard,
   Hexadecimal: Hexadecimal.Guard,
   ISODateString: ISODateString.Guard,
   IntString: IntString.Guard,

--- a/src/SchemableExt.ts
+++ b/src/SchemableExt.ts
@@ -24,6 +24,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export interface SchemableExt<S> extends SchemableHKT2<S> {
   readonly Base64Url: Base64Url.SchemableParams<S>
   readonly BtcAddress: BtcAddress.SchemableParams<S>
   readonly EmailAddress: EmailAddress.SchemableParams<S>
+  readonly HexColor: HexColor.SchemableParams<S>
   readonly Hexadecimal: Hexadecimal.SchemableParams<S>
   readonly ISODateString: ISODateString.SchemableParams<S>
   readonly IntString: IntString.SchemableParams<S>
@@ -89,6 +91,7 @@ export interface SchemableExt1<S extends URIS> extends Schemable1<S> {
   readonly Base64Url: Base64Url.SchemableParams1<S>
   readonly BtcAddress: BtcAddress.SchemableParams1<S>
   readonly EmailAddress: EmailAddress.SchemableParams1<S>
+  readonly HexColor: HexColor.SchemableParams1<S>
   readonly Hexadecimal: Hexadecimal.SchemableParams1<S>
   readonly ISODateString: ISODateString.SchemableParams1<S>
   readonly IntString: IntString.SchemableParams1<S>
@@ -121,6 +124,7 @@ export interface SchemableExt2<S extends URIS2> extends Schemable2<S> {
   readonly Base64Url: Base64Url.SchemableParams2<S>
   readonly BtcAddress: BtcAddress.SchemableParams2<S>
   readonly EmailAddress: EmailAddress.SchemableParams2<S>
+  readonly HexColor: HexColor.SchemableParams2<S>
   readonly Hexadecimal: Hexadecimal.SchemableParams2<S>
   readonly ISODateString: ISODateString.SchemableParams2<S>
   readonly IntString: IntString.SchemableParams2<S>
@@ -153,6 +157,7 @@ export interface SchemableExt2C<S extends URIS2> extends Schemable2C<S, unknown>
   readonly Base64Url: Base64Url.SchemableParams2C<S>
   readonly BtcAddress: BtcAddress.SchemableParams2C<S>
   readonly EmailAddress: EmailAddress.SchemableParams2C<S>
+  readonly HexColor: HexColor.SchemableParams2C<S>
   readonly Hexadecimal: Hexadecimal.SchemableParams2C<S>
   readonly ISODateString: ISODateString.SchemableParams2C<S>
   readonly IntString: IntString.SchemableParams2C<S>

--- a/src/SchemableExt.ts
+++ b/src/SchemableExt.ts
@@ -24,6 +24,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export interface SchemableExt<S> extends SchemableHKT2<S> {
   readonly Base64Url: Base64Url.SchemableParams<S>
   readonly BtcAddress: BtcAddress.SchemableParams<S>
   readonly EmailAddress: EmailAddress.SchemableParams<S>
+  readonly Hexadecimal: Hexadecimal.SchemableParams<S>
   readonly ISODateString: ISODateString.SchemableParams<S>
   readonly IntString: IntString.SchemableParams<S>
   readonly JWT: JWT.SchemableParams<S>
@@ -87,6 +89,7 @@ export interface SchemableExt1<S extends URIS> extends Schemable1<S> {
   readonly Base64Url: Base64Url.SchemableParams1<S>
   readonly BtcAddress: BtcAddress.SchemableParams1<S>
   readonly EmailAddress: EmailAddress.SchemableParams1<S>
+  readonly Hexadecimal: Hexadecimal.SchemableParams1<S>
   readonly ISODateString: ISODateString.SchemableParams1<S>
   readonly IntString: IntString.SchemableParams1<S>
   readonly JWT: JWT.SchemableParams1<S>
@@ -118,6 +121,7 @@ export interface SchemableExt2<S extends URIS2> extends Schemable2<S> {
   readonly Base64Url: Base64Url.SchemableParams2<S>
   readonly BtcAddress: BtcAddress.SchemableParams2<S>
   readonly EmailAddress: EmailAddress.SchemableParams2<S>
+  readonly Hexadecimal: Hexadecimal.SchemableParams2<S>
   readonly ISODateString: ISODateString.SchemableParams2<S>
   readonly IntString: IntString.SchemableParams2<S>
   readonly JWT: JWT.SchemableParams2<S>
@@ -149,6 +153,7 @@ export interface SchemableExt2C<S extends URIS2> extends Schemable2C<S, unknown>
   readonly Base64Url: Base64Url.SchemableParams2C<S>
   readonly BtcAddress: BtcAddress.SchemableParams2C<S>
   readonly EmailAddress: EmailAddress.SchemableParams2C<S>
+  readonly Hexadecimal: Hexadecimal.SchemableParams2C<S>
   readonly ISODateString: ISODateString.SchemableParams2C<S>
   readonly IntString: IntString.SchemableParams2C<S>
   readonly JWT: JWT.SchemableParams2C<S>

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt2C<TD.URI> = {
   Base64Url: Base64Url.TaskDecoder,
   BtcAddress: BtcAddress.TaskDecoder,
   EmailAddress: EmailAddress.TaskDecoder,
+  Hexadecimal: Hexadecimal.TaskDecoder,
   ISODateString: ISODateString.TaskDecoder,
   IntString: IntString.TaskDecoder,
   JWT: JWT.TaskDecoder,

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt2C<TD.URI> = {
   Base64Url: Base64Url.TaskDecoder,
   BtcAddress: BtcAddress.TaskDecoder,
   EmailAddress: EmailAddress.TaskDecoder,
+  HexColor: HexColor.TaskDecoder,
   Hexadecimal: Hexadecimal.TaskDecoder,
   ISODateString: ISODateString.TaskDecoder,
   IntString: IntString.TaskDecoder,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
 import * as JWT from './string/JWT'
@@ -56,6 +57,7 @@ export const Schemable: SchemableExt1<t.URI> = {
   Base64Url: Base64Url.Type,
   BtcAddress: BtcAddress.Type,
   EmailAddress: EmailAddress.Type,
+  Hexadecimal: Hexadecimal.Type,
   ISODateString: ISODateString.Type,
   IntString: IntString.Type,
   JWT: JWT.Type,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -23,6 +23,7 @@ import * as Base64 from './string/Base64'
 import * as Base64Url from './string/Base64Url'
 import * as BtcAddress from './string/BtcAddress'
 import * as EmailAddress from './string/EmailAddress'
+import * as HexColor from './string/HexColor'
 import * as Hexadecimal from './string/Hexadecimal'
 import * as ISODateString from './string/ISODateString'
 import * as IntString from './string/IntString'
@@ -57,6 +58,7 @@ export const Schemable: SchemableExt1<t.URI> = {
   Base64Url: Base64Url.Type,
   BtcAddress: BtcAddress.Type,
   EmailAddress: EmailAddress.Type,
+  HexColor: HexColor.Type,
   Hexadecimal: Hexadecimal.Type,
   ISODateString: ISODateString.Type,
   IntString: IntString.Type,

--- a/src/string/HexColor.ts
+++ b/src/string/HexColor.ts
@@ -1,0 +1,113 @@
+/**
+ * A valid hexadecimal color value.
+ *
+ * Inspired by
+ * [isHexColor](https://github.com/validatorjs/validator.js/blob/master/src/lib/isHexColor.js)
+ *
+ * @since 0.0.3
+ */
+import { Kind, Kind2, URIS, URIS2, HKT2 } from 'fp-ts/HKT'
+import * as D from 'io-ts/Decoder'
+import * as Enc from 'io-ts/Encoder'
+import * as Eq_ from 'fp-ts/Eq'
+import * as G from 'io-ts/Guard'
+import * as Str from 'fp-ts/string'
+import * as TD from 'io-ts/TaskDecoder'
+import * as t from 'io-ts/Type'
+import { pipe } from 'fp-ts/function'
+
+/**
+ * @since 0.0.3
+ * @category Internal
+ */
+interface HexColorBrand {
+  readonly HexColor: unique symbol
+}
+
+/**
+ * A valid hexadecimal color value.
+ *
+ * Inspired by
+ * [isHexColor](https://github.com/validatorjs/validator.js/blob/master/src/lib/isHexColor.js)
+ *
+ * @since 0.0.3
+ * @category Model
+ */
+export type HexColor = string & HexColorBrand
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams<S> = HKT2<S, string, HexColor>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams1<S extends URIS> = Kind<S, HexColor>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2<S extends URIS2> = Kind2<S, string, HexColor>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, HexColor>
+
+const hexcolor = /^#?([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$/i
+
+/**
+ * @since 0.0.3
+ * @category Refinements
+ */
+export const isHexColor = (s: string): s is HexColor => hexcolor.test(s)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Decoder: SchemableParams2C<D.URI> = pipe(
+  D.string,
+  D.refine(isHexColor, 'HexColor')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Encoder: SchemableParams2<Enc.URI> = Enc.id()
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Eq: SchemableParams1<Eq_.URI> = Str.Eq
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isHexColor))
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const TaskDecoder: SchemableParams2C<TD.URI> = pipe(
+  TD.string,
+  TD.refine(isHexColor, 'HexColor')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Type: SchemableParams1<t.URI> = pipe(
+  t.string,
+  t.refine(isHexColor, 'HexColor')
+)

--- a/src/string/HexColor.ts
+++ b/src/string/HexColor.ts
@@ -59,6 +59,10 @@ export type SchemableParams2<S extends URIS2> = Kind2<S, string, HexColor>
  */
 export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, HexColor>
 
+/**
+ * @since 0.0.3
+ * @category Internal
+ */
 const hexcolor = /^#?([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$/i
 
 /**

--- a/src/string/Hexadecimal.ts
+++ b/src/string/Hexadecimal.ts
@@ -1,0 +1,117 @@
+/**
+ * A string of hexadecimal characters.
+ *
+ * Inspired by
+ * [isHexadecimal](https://github.com/validatorjs/validator.js/blob/master/src/lib/isHexadecimal.js)
+ *
+ * @since 0.0.3
+ */
+import { Kind, Kind2, URIS, URIS2, HKT2 } from 'fp-ts/HKT'
+import * as D from 'io-ts/Decoder'
+import * as Enc from 'io-ts/Encoder'
+import * as Eq_ from 'fp-ts/Eq'
+import * as G from 'io-ts/Guard'
+import * as Str from 'fp-ts/string'
+import * as TD from 'io-ts/TaskDecoder'
+import * as t from 'io-ts/Type'
+import { pipe } from 'fp-ts/function'
+
+/**
+ * @since 0.0.3
+ * @category Internal
+ */
+interface HexadecimalBrand {
+  readonly Hexadecimal: unique symbol
+}
+
+/**
+ * A string of hexadecimal characters.
+ *
+ * Inspired by
+ * [isHexadecimal](https://github.com/validatorjs/validator.js/blob/master/src/lib/isHexadecimal.js)
+ *
+ * @since 0.0.3
+ * @category Model
+ */
+export type Hexadecimal = string & HexadecimalBrand
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams<S> = HKT2<S, string, Hexadecimal>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams1<S extends URIS> = Kind<S, Hexadecimal>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2<S extends URIS2> = Kind2<S, string, Hexadecimal>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, Hexadecimal>
+
+/**
+ * @since 0.0.3
+ * @category Internal
+ */
+const reHex = /^(0x|0h)?[0-9A-F]+$/i
+
+/**
+ * @since 0.0.3
+ * @category Refinements
+ */
+export const isHexadecimal = (s: string): s is Hexadecimal => reHex.test(s)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Decoder: SchemableParams2C<D.URI> = pipe(
+  D.string,
+  D.refine(isHexadecimal, 'Hexadecimal')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Encoder: SchemableParams2<Enc.URI> = Enc.id()
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Eq: SchemableParams1<Eq_.URI> = Str.Eq
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isHexadecimal))
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const TaskDecoder: SchemableParams2C<TD.URI> = pipe(
+  TD.string,
+  TD.refine(isHexadecimal, 'Hexadecimal')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Type: SchemableParams1<t.URI> = pipe(
+  t.string,
+  t.refine(isHexadecimal, 'Hexadecimal')
+)

--- a/tests/Base64.test.ts
+++ b/tests/Base64.test.ts
@@ -40,8 +40,8 @@ describe('Base64', () => {
   describe('Decoder', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Decoder.decode(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Decoder.decode(str)
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -51,15 +51,15 @@ describe('Base64', () => {
     test.each(RA.zipWith(validStrings, validStrings, tuple))(
       'determines two strings are equal',
 
-      (num1, num2) => {
+      (str1, str2) => {
         const guard = Guard.is
         const eq = Eq.equals
 
-        if (!guard(num1) || !guard(num2)) {
+        if (!guard(str1) || !guard(str2)) {
           throw new Error('Unexpected result')
         }
 
-        expect(eq(num1, num2)).toBe(true)
+        expect(eq(str1, str2)).toBe(true)
       }
     )
   })
@@ -67,8 +67,8 @@ describe('Base64', () => {
   describe('Guard', () => {
     test.each(
       cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Guard.is(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Guard.is(str)
 
       expect(result).toBe(expectedTag)
     })
@@ -77,8 +77,8 @@ describe('Base64', () => {
   describe('TaskDecoder', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', async (num, expectedTag) => {
-      const result = await TaskDecoder.decode(num)()
+    )('validates valid strings, and catches bad strings', async (str, expectedTag) => {
+      const result = await TaskDecoder.decode(str)()
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -87,8 +87,8 @@ describe('Base64', () => {
   describe('Type', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Type.decode(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Type.decode(str)
 
       expect(result._tag).toBe(expectedTag)
     })

--- a/tests/Base64Url.test.ts
+++ b/tests/Base64Url.test.ts
@@ -28,8 +28,8 @@ describe('Base64Url', () => {
   describe('Decoder', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Decoder.decode(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Decoder.decode(str)
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -39,15 +39,15 @@ describe('Base64Url', () => {
     test.each(RA.zipWith(validStrings, validStrings, tuple))(
       'determines two strings are equal',
 
-      (num1, num2) => {
+      (str1, str2) => {
         const guard = Guard.is
         const eq = Eq.equals
 
-        if (!guard(num1) || !guard(num2)) {
+        if (!guard(str1) || !guard(str2)) {
           throw new Error('Unexpected result')
         }
 
-        expect(eq(num1, num2)).toBe(true)
+        expect(eq(str1, str2)).toBe(true)
       }
     )
   })
@@ -55,8 +55,8 @@ describe('Base64Url', () => {
   describe('Guard', () => {
     test.each(
       cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Guard.is(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Guard.is(str)
 
       expect(result).toBe(expectedTag)
     })
@@ -65,8 +65,8 @@ describe('Base64Url', () => {
   describe('TaskDecoder', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', async (num, expectedTag) => {
-      const result = await TaskDecoder.decode(num)()
+    )('validates valid strings, and catches bad strings', async (str, expectedTag) => {
+      const result = await TaskDecoder.decode(str)()
 
       expect(result._tag).toBe(expectedTag)
     })
@@ -75,8 +75,8 @@ describe('Base64Url', () => {
   describe('Type', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
-    )('validates valid strings, and catches bad strings', (num, expectedTag) => {
-      const result = Type.decode(num)
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Type.decode(str)
 
       expect(result._tag).toBe(expectedTag)
     })

--- a/tests/HexColor.test.ts
+++ b/tests/HexColor.test.ts
@@ -1,0 +1,87 @@
+import * as RA from 'fp-ts/ReadonlyArray'
+import * as E from 'fp-ts/Either'
+
+import { pipe, tuple } from 'fp-ts/function'
+
+import { Decoder, Eq, Encoder, Guard, TaskDecoder, Type } from '../src/string/HexColor'
+
+import { cat, combineExpected } from '../test-utils'
+
+const validStrings = ['#ff0000ff', '#ff0034', '#CCCCCC', '0f38', 'fff', '#f00']
+
+const invalidStrings = ['#ff', 'fff0a', '#ff12FG', '#bbh']
+
+describe('Hexadecimal', () => {
+  describe('Decoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Decoder.decode(str)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Encoder', () => {
+    test.each(validStrings)(
+      'encoding a decoded value yields original value',
+      original => {
+        const roundtrip = pipe(
+          original,
+          Decoder.decode,
+          E.map(Encoder.encode),
+          E.getOrElse(() => 'invalid')
+        )
+
+        expect(original).toEqual(roundtrip)
+      }
+    )
+  })
+
+  describe('Eq', () => {
+    test.each(RA.zipWith(validStrings, validStrings, tuple))(
+      'determines two strings are equal',
+
+      (str1, str2) => {
+        const guard = Guard.is
+        const eq = Eq.equals
+
+        if (!guard(str1) || !guard(str2)) {
+          throw new Error('Unexpected result')
+        }
+
+        expect(eq(str1, str2)).toBe(true)
+      }
+    )
+  })
+
+  describe('Guard', () => {
+    test.each(
+      cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Guard.is(str)
+
+      expect(result).toBe(expectedTag)
+    })
+  })
+
+  describe('TaskDecoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', async (str, expectedTag) => {
+      const result = await TaskDecoder.decode(str)()
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Type', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Type.decode(str)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+})

--- a/tests/HexColor.test.ts
+++ b/tests/HexColor.test.ts
@@ -11,7 +11,7 @@ const validStrings = ['#ff0000ff', '#ff0034', '#CCCCCC', '0f38', 'fff', '#f00']
 
 const invalidStrings = ['#ff', 'fff0a', '#ff12FG', '#bbh']
 
-describe('Hexadecimal', () => {
+describe('HexColor', () => {
   describe('Decoder', () => {
     test.each(
       cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))

--- a/tests/Hexadecimal.test.ts
+++ b/tests/Hexadecimal.test.ts
@@ -1,0 +1,106 @@
+import * as RA from 'fp-ts/ReadonlyArray'
+import * as E from 'fp-ts/Either'
+
+import { pipe, tuple } from 'fp-ts/function'
+
+import { Decoder, Eq, Encoder, Guard, TaskDecoder, Type } from '../src/string/Hexadecimal'
+
+import { cat, combineExpected } from '../test-utils'
+
+const validStrings = [
+  'deadBEEF',
+  'ff0044',
+  '0xff0044',
+  '0XfF0044',
+  '0x0123456789abcDEF',
+  '0X0123456789abcDEF',
+  '0hfedCBA9876543210',
+  '0HfedCBA9876543210',
+  '0123456789abcDEF',
+]
+
+const invalidStrings = [
+  'abcdefg',
+  '',
+  '..',
+  '0xa2h',
+  '0xa20x',
+  '0x0123456789abcDEFq',
+  '0hfedCBA9876543210q',
+  '01234q56789abcDEF',
+]
+
+describe('Hexadecimal', () => {
+  describe('Decoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Decoder.decode(str)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Encoder', () => {
+    test.each(validStrings)(
+      'encoding a decoded value yields original value',
+      original => {
+        const roundtrip = pipe(
+          original,
+          Decoder.decode,
+          E.map(Encoder.encode),
+          E.getOrElse(() => 'invalid')
+        )
+
+        expect(original).toEqual(roundtrip)
+      }
+    )
+  })
+
+  describe('Eq', () => {
+    test.each(RA.zipWith(validStrings, validStrings, tuple))(
+      'determines two strings are equal',
+
+      (str1, str2) => {
+        const guard = Guard.is
+        const eq = Eq.equals
+
+        if (!guard(str1) || !guard(str2)) {
+          throw new Error('Unexpected result')
+        }
+
+        expect(eq(str1, str2)).toBe(true)
+      }
+    )
+  })
+
+  describe('Guard', () => {
+    test.each(
+      cat(combineExpected(validStrings, true), combineExpected(invalidStrings, false))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Guard.is(str)
+
+      expect(result).toBe(expectedTag)
+    })
+  })
+
+  describe('TaskDecoder', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', async (str, expectedTag) => {
+      const result = await TaskDecoder.decode(str)()
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+
+  describe('Type', () => {
+    test.each(
+      cat(combineExpected(validStrings, 'Right'), combineExpected(invalidStrings, 'Left'))
+    )('validates valid strings, and catches bad strings', (str, expectedTag) => {
+      const result = Type.decode(str)
+
+      expect(result._tag).toBe(expectedTag)
+    })
+  })
+})


### PR DESCRIPTION
This PR does the following:

- Adds `Hexadecimal` and `HexColor` modules
- Bumps package version to `0.0.3`
- Adds a check for Node v18 to the build process
- Fixes some small typos in some of the string tests

Closes #61 
Closes #18 