### PR TITLE
[#14] Add CreditCard string module

### DIFF
--- a/src/internal/algorithms.ts
+++ b/src/internal/algorithms.ts
@@ -1,0 +1,26 @@
+import { flow } from 'fp-ts/function'
+import { MonoidSum } from 'fp-ts/number'
+import * as RA from 'fp-ts/ReadonlyArray'
+import * as Str from 'fp-ts/string'
+
+/**
+ * This calculates the Luhn checksum for a given string of digits.
+ *
+ * @internal
+ */
+export const luhn: (cc: string) => number = flow(
+  Str.split(''),
+  RA.reverse,
+  RA.map(d => parseInt(d)),
+  RA.foldMapWithIndex(MonoidSum)((i, d) =>
+    i % 2 === 1
+      ? // numbers of odd rank stay the same
+        d
+      : // numbers of even rank get doubled, then their digits are summed
+      d * 2 >= 10
+      ? 1 + (d * 2 - 10)
+      : d * 2
+  ),
+  sum => (sum % 10) % 10,
+  checksum => (checksum === 0 ? 0 : 10 - checksum)
+)

--- a/src/internal/algorithms.ts
+++ b/src/internal/algorithms.ts
@@ -21,6 +21,5 @@ export const luhn: (cc: string) => number = flow(
       ? 1 + (d * 2 - 10)
       : d * 2
   ),
-  sum => (sum % 10) % 10,
-  checksum => (checksum === 0 ? 0 : 10 - checksum)
+  sum => (10 - (sum % 10)) % 10
 )

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -1,3 +1,5 @@
+import fc, { Arbitrary } from 'fast-check'
+
 /** @internal */
 export const base64Encode = (s: string): string =>
   Buffer ? Buffer.from(s).toString('base64') : btoa(s)
@@ -5,3 +7,9 @@ export const base64Encode = (s: string): string =>
 /** @internal */
 export const urlifyBase64 = (s: string): string =>
   s.replace(/[=+/]/g, c => (c === '/' ? '_' : c === '+' ? '-' : c === '=' ? '' : c))
+
+/** @internal */
+export const digits = (ns: ReadonlyArray<number>): Arbitrary<string> =>
+  fc
+    .oneof(...ns.map(n => fc.array(fc.nat({ max: 9 }), { maxLength: n, minLength: n })))
+    .map(ds => ds.join(''))

--- a/src/string/CreditCard.ts
+++ b/src/string/CreditCard.ts
@@ -1,0 +1,168 @@
+/**
+ * TODO: Add module comment
+ *
+ * @since 0.0.3
+ */
+import { Kind, Kind2, URIS, URIS2, HKT2 } from 'fp-ts/HKT'
+import * as D from 'io-ts/Decoder'
+import * as Enc from 'io-ts/Encoder'
+import * as Eq_ from 'fp-ts/Eq'
+import * as G from 'io-ts/Guard'
+import * as Str from 'fp-ts/string'
+import * as TD from 'io-ts/TaskDecoder'
+import * as t from 'io-ts/Type'
+import { flow, pipe } from 'fp-ts/function'
+import * as fc from 'fast-check'
+import * as RA from 'fp-ts/ReadonlyArray'
+
+import * as Arb from '../internal/ArbitraryBase'
+import { MonoidSum } from 'fp-ts/lib/number'
+import { digits } from '../internal/util'
+
+/**
+ * @since 0.0.3
+ * @category Internal
+ */
+interface CreditCardBrand {
+  readonly CreditCard: unique symbol
+}
+
+/**
+ * TODO: Add module comment
+ *
+ * @since 0.0.3
+ * @category Model
+ */
+export type CreditCard = string & CreditCardBrand
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams<S> = HKT2<S, string, CreditCard>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams1<S extends URIS> = Kind<S, CreditCard>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2<S extends URIS2> = Kind2<S, string, CreditCard>
+
+/**
+ * @since 0.0.3
+ * @category Model
+ */
+export type SchemableParams2C<S extends URIS2> = Kind2<S, unknown, CreditCard>
+
+const cc =
+  /(^4[0-9]{12}(?:[0-9]{3})?$)|(^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$)|(3[47][0-9]{13})|(^3(?:0[0-5]|[68][0-9])[0-9]{11}$)|(^6(?:011|5[0-9]{2})[0-9]{12}$)|(^(?:2131|1800|35\d{3})\d{11}$)/
+
+/** This calculates the Luhn checksum for a given string of digits. */
+const luhn: (cc: string) => number = flow(
+  Str.split(''),
+  RA.reverse,
+  RA.map(d => parseInt(d)),
+  RA.foldMapWithIndex(MonoidSum)((i, d) =>
+    i % 2 === 1
+      ? // numbers of odd rank stay the same
+        d
+      : // numbers of even rank get doubled, then their digits are summed
+      d * 2 >= 10
+      ? 1 + (d * 2 - 10)
+      : d * 2
+  ),
+  sum => (sum % 10) % 10,
+  checksum => (checksum === 0 ? 0 : 10 - checksum)
+)
+
+/**
+ * @since 0.0.3
+ * @category Refinements
+ */
+export const isCreditCard = (s: string): s is CreditCard => {
+  const clean = s.replace(/[^0-9]/g, '')
+  return cc.test(clean) && luhn(clean.slice(0, -1)) === parseInt(clean.slice(-1))
+}
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Decoder: SchemableParams2C<D.URI> = pipe(
+  D.string,
+  D.refine(isCreditCard, 'CreditCard')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Encoder: SchemableParams2<Enc.URI> = Enc.id()
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Eq: SchemableParams1<Eq_.URI> = Str.Eq
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Guard: SchemableParams1<G.URI> = pipe(G.string, G.refine(isCreditCard))
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const TaskDecoder: SchemableParams2C<TD.URI> = pipe(
+  TD.string,
+  TD.refine(isCreditCard, 'CreditCard')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Type: SchemableParams1<t.URI> = pipe(
+  t.string,
+  t.refine(isCreditCard, 'CreditCard')
+)
+
+/**
+ * @since 0.0.3
+ * @category Instances
+ */
+export const Arbitrary: SchemableParams1<Arb.URI> = fc
+  .oneof(
+    // visa
+    digits([11, 14]).map(acct => `4${acct}`),
+    // mastercard
+    fc.oneof(
+      fc
+        .integer({ min: 2221, max: 2720 })
+        .chain(iin => digits([11]).map(acct => `${iin}${acct}`)),
+      fc
+        .integer({ min: 51, max: 55 })
+        .chain(iin => digits([13]).map(acct => `${iin}${acct}`))
+    ),
+    // amex
+    digits([12]).chain(acct => fc.constantFrom('34', '37').map(iin => `${iin}${acct}`)),
+    // diners club
+    digits([11]).map(acct => `36${acct}`),
+    // discover
+    fc.oneof(
+      digits([11]).map(acct => `6011${acct}`),
+      digits([13]).map(acct => `65${acct}`)
+    ),
+    // jcb
+    digits([11]).chain(acct =>
+      fc.integer({ min: 3528, max: 3589 }).map(iin => `${iin}${acct}`)
+    )
+  )
+  .map(num => `${num}${luhn(num.replace(/[^0-9]/g, ''))}`) as Arb.Arbitrary<CreditCard>

--- a/tests/string/CreditCard.test.ts
+++ b/tests/string/CreditCard.test.ts
@@ -56,4 +56,51 @@ describe('CreditCard', () => {
       validateArbitrary(CreditCard, CreditCard.isCreditCard)
     })
   })
+
+  describe('validators.js test cases', () => {
+    // NOTE: If a test case here is commented out,
+    // it existed in the validators.js test cases but I cannot find any
+    // corroboration that it should be considered valid.
+    test.each([
+      '375556917985515',
+      '36050234196908',
+      '4716461583322103',
+      '4716-2210-5188-5662',
+      '4929 7226 5379 7141',
+      '5398228707871527',
+      '6283875070985593',
+      '6263892624162870',
+      //'6234917882863855',
+      //'6234698580215388',
+      '6226050967750613',
+      '6246281879460688',
+      '2222155765072228',
+      '2225855203075256',
+      '2720428011723762',
+      '2718760626256570',
+      // '6765780016990268',
+      // '4716989580001715211',
+      '8171999927660000',
+      // '8171999900000000021',
+    ])('%s is valid', ccn => {
+      expect(CreditCard.Guard.is(ccn)).toBe(true)
+    })
+
+    test.each([
+      'foo',
+      'foo',
+      '5398228707871528',
+      '2718760626256571',
+      '2721465526338453',
+      '2220175103860763',
+      '375556917985515999999993',
+      '899999996234917882863855',
+      'prefix6234917882863855',
+      '623491788middle2863855',
+      '6234917882863855suffix',
+      '4716989580001715213',
+    ])('%s is invalid', ccn => {
+      expect(CreditCard.Guard.is(ccn)).toBe(false)
+    })
+  })
 })

--- a/tests/string/CreditCard.test.ts
+++ b/tests/string/CreditCard.test.ts
@@ -1,0 +1,59 @@
+import * as CreditCard from '../../src/string/CreditCard'
+import { validateArbitrary } from '../../test-utils'
+
+describe('CreditCard', () => {
+  // this was generated with a random site, afaik it's not a "real" number
+  const realishCC = '4485-5502-3668-4973'
+
+  describe('Decoder', () => {
+    it('catches an invalid string', () => {
+      const result = CreditCard.Decoder.decode('1234')
+      expect(result._tag).toBe('Left')
+    })
+
+    it('validates a valid CreditCard string', () => {
+      const result = CreditCard.Decoder.decode(realishCC)
+      expect(result._tag).toBe('Right')
+    })
+  })
+
+  describe('Guard', () => {
+    it('guards against invalid CreditCard characters', () => {
+      expect(CreditCard.Guard.is('123')).toBe(false)
+    })
+
+    it('permits a valid CreditCard characters', () => {
+      expect(CreditCard.Guard.is(realishCC)).toBe(true)
+    })
+  })
+
+  describe('TaskDecoder', () => {
+    it('invalidates an invalid CreditCard string', async () => {
+      const result = await CreditCard.TaskDecoder.decode('1234')()
+      expect(result._tag).toBe('Left')
+    })
+
+    it('validates an valid CreditCard string', async () => {
+      const result = await CreditCard.TaskDecoder.decode(realishCC)()
+      expect(result._tag).toBe('Right')
+    })
+  })
+
+  describe('Type', () => {
+    it('decodes an invalid CreditCard string', () => {
+      const result = CreditCard.Type.decode('123')
+      expect(result._tag).toBe('Left')
+    })
+
+    it('decodes an invalid CreditCard string', () => {
+      const result = CreditCard.Type.decode(realishCC)
+      expect(result._tag).toBe('Right')
+    })
+  })
+
+  describe('Arbitrary', () => {
+    it('generates valid CreditCard strings', () => {
+      validateArbitrary(CreditCard, CreditCard.isCreditCard)
+    })
+  })
+})


### PR DESCRIPTION
Used a few sources for this.

The regex is a straight rip from https://ihateregex.io/expr/credit-card/

For the `Arbitrary`, I tried to use https://en.wikipedia.org/wiki/Payment_card_number but I ran into some issues with the regex (maybe it's out of date, or just doesn't bother to try matching all the possible credit cards, even among those it says it matches). Between that and the more restrictive lengths found [here](https://www.validcreditcardnumber.com/) I was able to get it passing its own checks.

Closes #14